### PR TITLE
Changes

### DIFF
--- a/bin/itchy
+++ b/bin/itchy
@@ -49,8 +49,10 @@ class ItchyRunnable < Thor
   desc 'archive', 'Handle an incoming vmcatcher event and store it for further processing'
   method_option :metadata_dir, type: :string, default: Itchy::Settings.metadata_dir,
                                aliases: '-m', desc: 'Path to a metadata directory for storing events, must be writable'
-  method_option :log_to, type: :string, default: Itchy::Settings.log_to.archive_log, aliasses: '-d',
+  method_option :log_to, type: :string, default: Itchy::Settings.log_to.archive_log, aliasses: '-l',
                                 desc: 'Logging output, file path or stderr/stdout'
+  method_option :file_permissions, type: :string, default: Itchy::Settings['permissions']['file'],
+                    aliases: '-p', desc: 'Sets permissions for all created files'
   method_option *shared_option_log_level
   method_option *shared_option_debug
 
@@ -79,7 +81,7 @@ class ItchyRunnable < Thor
                                  aliases: '-e', desc: 'Path to a directory where appliance descriptors will be stored'
   method_option :file_permissions, type: :string, default: Itchy::Settings['permissions']['file'],
                                 aliases: '-p', desc: 'Sets permissions for all created files'
-  method_option :log_to, type: :string, default: Itchy::Settings.log_to.process_log, aliases: '-d',
+  method_option :log_to, type: :string, default: Itchy::Settings.log_to.process_log, aliases: '-l',
                                 desc: 'Logging output, file path or stderr/stdout'
   method_option *shared_option_log_level
   method_option *shared_option_debug

--- a/bin/itchy
+++ b/bin/itchy
@@ -33,9 +33,6 @@ class ItchyRunnable < Thor
   AVAILABLE_AUTH_METHODS = %w(none basic).freeze
   ERROR_EXIT_CODE = 1
 
-  shared_option_log_to = [:log_to, { type: :string, default: Itchy::Settings.log_to,
-                                     aliases: '-l', desc: 'Logging output, file path or stderr/stdout' }]
-
   shared_option_log_level = [:log_level, { enum: AVAILABLE_LOG_LEVELS,
                                            default: Itchy::Settings.log_level,
                                            aliases: '-b', desc: 'Logging level' }]
@@ -52,7 +49,8 @@ class ItchyRunnable < Thor
   desc 'archive', 'Handle an incoming vmcatcher event and store it for further processing'
   method_option :metadata_dir, type: :string, default: Itchy::Settings.metadata_dir,
                                aliases: '-m', desc: 'Path to a metadata directory for storing events, must be writable'
-  method_option *shared_option_log_to
+  method_option :log_to, type: :string, default: Itchy::Settings.log_to.archive_log, aliasses: '-d',
+                                desc: 'Logging output, file path or stderr/stdout'
   method_option *shared_option_log_level
   method_option *shared_option_debug
 
@@ -81,7 +79,8 @@ class ItchyRunnable < Thor
                                  aliases: '-e', desc: 'Path to a directory where appliance descriptors will be stored'
   method_option :file_permissions, type: :string, default: Itchy::Settings['permissions']['file'],
                                 aliases: '-p', desc: 'Sets permissions for all created files'
-  method_option *shared_option_log_to
+  method_option :log_to, type: :string, default: Itchy::Settings.log_to.process_log, aliases: '-d',
+                                desc: 'Logging output, file path or stderr/stdout'
   method_option *shared_option_log_level
   method_option *shared_option_debug
 

--- a/config/itchy.yml
+++ b/config/itchy.yml
@@ -3,7 +3,9 @@ defaults: &defaults
   metadata_dir: /var/spool/itchy/metadata
   output_dir: /var/spool/itchy/output
   descriptor_dir: /var/spool/itchy/descriptors
-  log_to: stderr
+  log_to:
+    archive_log: stderr
+    process_log: stderr
   log_level: error
   debug: false
   permissions:

--- a/lib/itchy/event_handlers/base_event_handler.rb
+++ b/lib/itchy/event_handlers/base_event_handler.rb
@@ -44,6 +44,7 @@ module Itchy::EventHandlers
       temp_file.flush
 
       ::FileUtils.cp(temp_file.path, permanent_file_path)
+      set_file_permissions(permanent_file_path)
       temp_file.close
 
       true

--- a/lib/itchy/event_processer.rb
+++ b/lib/itchy/event_processer.rb
@@ -72,7 +72,7 @@ module Itchy
       Itchy::VmcatcherEvent.new(::File.read(json))
     rescue => ex
       Itchy::Log.error 'Failed to load event!!!'
-      return ex
+      return false
     end
 
     # Deletes event file.

--- a/lib/itchy/version.rb
+++ b/lib/itchy/version.rb
@@ -1,3 +1,3 @@
 module Itchy
-  VERSION = '0.2.3' unless defined?(::Itchy::VERSION)
+  VERSION = '0.2.4' unless defined?(::Itchy::VERSION)
 end


### PR DESCRIPTION
+ separated logs for archive and process
+ set file permissions for archived events
+ failed events are now reported (instead of "no method error")