### PR TITLE
Changes

### DIFF
--- a/bin/itchy
+++ b/bin/itchy
@@ -131,7 +131,7 @@ class ItchyRunnable < Thor
   method_option :qemu_img_binary,
                 type: :string,
                 default: Itchy::Settings['qemu_img_binary'],
-                aliases: '-q'
+                aliases: '-q',
                 desc: 'Path to qemu-img command binary, if not used, ITCHY will look for it in PATH'
 
   method_option *shared_option_log_level

--- a/bin/itchy
+++ b/bin/itchy
@@ -47,12 +47,25 @@ class ItchyRunnable < Thor
   end
 
   desc 'archive', 'Handle an incoming vmcatcher event and store it for further processing'
-  method_option :metadata_dir, type: :string, default: Itchy::Settings.metadata_dir,
-                               aliases: '-m', desc: 'Path to a metadata directory for storing events, must be writable'
-  method_option :log_to, type: :string, default: Itchy::Settings.log_to.archive_log, aliasses: '-l',
-                                desc: 'Logging output, file path or stderr/stdout'
-  method_option :file_permissions, type: :string, default: Itchy::Settings['permissions']['file'],
-                    aliases: '-p', desc: 'Sets permissions for all created files'
+  
+  method_option :metadata_dir,
+                type: :string,
+                default: Itchy::Settings.metadata_dir,
+                aliases: '-m',
+                desc: 'Path to a metadata directory for storing events, must be writable'
+  
+  method_option :log_to,
+                type: :string,
+                default: Itchy::Settings.log_to.archive_log,
+                aliasses: '-l',
+                desc: 'Logging output, file path or stderr/stdout'
+  
+  method_option :file_permissions,
+                type: :string,
+                default: Itchy::Settings['permissions']['file'],
+                aliases: '-p',
+                desc: 'Sets permissions for all created files'
+  
   method_option *shared_option_log_level
   method_option *shared_option_debug
 
@@ -71,18 +84,49 @@ class ItchyRunnable < Thor
   end
 
   desc 'process', 'Process stored events'
-  method_option :metadata_dir, type: :string, default: Itchy::Settings.metadata_dir,
-                               aliases: '-m', desc: 'Path to a metadata directory for stored events'
-  method_option :required_format, type: :string, default: Itchy::Settings.output_image_format,
-                                  aliases: '-f', desc: 'Required output format of converted images'
-  method_option :output_dir, type: :string, default: Itchy::Settings.output_dir,
-                             aliases: '-o', desc: 'Path to a directory where processed events descriptors will be stored'
-  method_option :descriptor_dir, type: :string, default: Itchy::Settings.descriptor_dir,
-                                 aliases: '-e', desc: 'Path to a directory where appliance descriptors will be stored'
-  method_option :file_permissions, type: :string, default: Itchy::Settings['permissions']['file'],
-                                aliases: '-p', desc: 'Sets permissions for all created files'
-  method_option :log_to, type: :string, default: Itchy::Settings.log_to.process_log, aliases: '-l',
-                                desc: 'Logging output, file path or stderr/stdout'
+  
+  method_option :metadata_dir,
+                type: :string,
+                default: Itchy::Settings.metadata_dir,
+                aliases: '-m',
+                desc: 'Path to a metadata directory for stored events'
+  
+  method_option :required_format,
+                type: :string,
+                default: Itchy::Settings.output_image_format,
+                aliases: '-f',
+                desc: 'Required output format of converted images'
+  
+  method_option :output_dir,
+                type: :string,
+                default: Itchy::Settings.output_dir,
+                aliases: '-o',
+                desc: 'Path to a directory where processed events descriptors will be stored'
+  
+  method_option :temp_image_dir,
+                type: :string,
+                default: Itchy::Settings.temp_image_dir,
+                aliases: '-t',
+                desc: 'Path to a directory where images will be temporary stored while being processed'
+  
+  method_option :descriptor_dir,
+                type: :string,
+                default: Itchy::Settings.descriptor_dir,
+                aliases: '-e',
+                desc: 'Path to a directory where appliance descriptors will be stored'
+  
+  method_option :file_permissions,
+                type: :string,
+                default: Itchy::Settings['permissions']['file'],
+                aliases: '-p',
+                desc: 'Sets permissions for all created files'
+  
+  method_option :log_to,
+                type: :string,
+                default: Itchy::Settings.log_to.process_log,
+                aliases: '-l',
+                desc: 'Logging output, file path or stderr/stdout'
+  
   method_option *shared_option_log_level
   method_option *shared_option_debug
 

--- a/bin/itchy
+++ b/bin/itchy
@@ -130,7 +130,7 @@ class ItchyRunnable < Thor
   
   method_option :qemu_img_binary,
                 type: :string,
-                default: Itchy::Settings.qemu_img_binary,
+                default: Itchy::Settings['qemu_img_binary'],
                 aliases: '-q'
                 desc: 'Path to qemu-img command binary, if not used, ITCHY will look for it in PATH'
 

--- a/bin/itchy
+++ b/bin/itchy
@@ -127,6 +127,13 @@ class ItchyRunnable < Thor
                 aliases: '-l',
                 desc: 'Logging output, file path or stderr/stdout'
   
+  
+  method_option :qemu_img_binary,
+                type: :string,
+                default: Itchy::Settings.qemu_img_binary,
+                aliases: '-q'
+                desc: 'Path to qemu-img command binary, if not used, ITCHY will look for it in PATH'
+
   method_option *shared_option_log_level
   method_option *shared_option_debug
 

--- a/config/itchy.yml
+++ b/config/itchy.yml
@@ -12,7 +12,7 @@ defaults: &defaults
   permissions:
     file: '0664'
   output_image_format: qcow2
-  qemu_img_binary: /usr/bin/qemu-img
+  #qemu_img_binary: # When used, ITCHY will use this binary to run qemu-img command (converting images)
 
 ###############################################
 #######  DO NOT EDIT AFTER THIS POINT  ########

--- a/config/itchy.yml
+++ b/config/itchy.yml
@@ -3,6 +3,7 @@ defaults: &defaults
   metadata_dir: /var/spool/itchy/metadata
   output_dir: /var/spool/itchy/output
   descriptor_dir: /var/spool/itchy/descriptors
+  temp_image_dir: /var/spool/itchy/temp
   log_to:
     archive_log: /var/log/itchy/archive.log
     process_log: /var/log/itchy/process.log

--- a/lib/itchy.rb
+++ b/lib/itchy.rb
@@ -9,7 +9,9 @@ require 'hashie/mash'
 require 'cloud-appliance-descriptor'
 
 # Wraps all internals of the handler.
-module Itchy; end
+module Itchy
+  BASIC_QEMU_COMMAND = 'qemu-img'
+end
 
 require 'itchy/version'
 require 'itchy/settings'

--- a/lib/itchy/format_converter.rb
+++ b/lib/itchy/format_converter.rb
@@ -2,7 +2,6 @@ module Itchy
   # Converting different image formats
   class FormatConverter
 
-    BASIC_QEMU_COMMAND = 'qemu-img'
 
     # Creates and converter instance for converting image to requried format
     #
@@ -33,7 +32,7 @@ module Itchy
                              "required format: #{required_format}."
 
       new_file_name = "#{::Time.now.to_i}_#{@metadata.dc_identifier}"
-      qemu_command = qemu_img_binary || BASIC_QEMU_COMMAND
+      qemu_command = qemu_img_binary || Itchy::BASIC_QEMU_COMMAND
       convert_cmd = Mixlib::ShellOut.new("#{qemu_command} convert -f #{file_format} -O #{required_format} #{@unpacking_dir}/#{@metadata.dc_identifier} #{output_dir}/#{new_file_name}")
       convert_cmd.run_command
       begin

--- a/lib/itchy/format_converter.rb
+++ b/lib/itchy/format_converter.rb
@@ -1,12 +1,16 @@
 module Itchy
   # Converting different image formats
   class FormatConverter
+
+    BASIC_QEMU_COMMAND = 'qemu-img'
+
     # Creates and converter instance for converting image to requried format
     #
     # @param unpacking_dir [String] path to directory where image is stored
     # @param metadata [VmcatcherEvent] metadata of event corresponding to image
     # @param vmcatcher_configuration [VmcatcherConfiguration] vmcatcher configuration
     def initialize(unpacking_dir, metadata, vmcatcher_configuration)
+      
       unless vmcatcher_configuration.is_a?(Itchy::VmcatcherConfiguration)
         fail ArgumentError, '\'vmcatcher_configuration\' must be an instance of ' \
                             'Itchy::VmcatcherConfiguration!'
@@ -22,14 +26,15 @@ module Itchy
     # @param file_format [String] actual format of the image
     # @param required_format [String] required format
     # @param output_dir [String] path to a directory where converted image should be stored
-    def convert!(file_format, required_format, output_dir)
+    def convert!(file_format, required_format, output_dir, qemu_img_binary)
       Itchy::Log.info "[#{self.class.name}] Converting image " \
                              "#{@metadata.dc_identifier.inspect} from " \
                              "original format: #{file_format} to " \
                              "required format: #{required_format}."
 
       new_file_name = "#{::Time.now.to_i}_#{@metadata.dc_identifier}"
-      convert_cmd = Mixlib::ShellOut.new("qemu-img convert -f #{file_format} -O #{required_format} #{@unpacking_dir}/#{@metadata.dc_identifier} #{output_dir}/#{new_file_name}")
+      qemu_command = qemu_img_binary || BASIC_QEMU_COMMAND
+      convert_cmd = Mixlib::ShellOut.new("#{qemu_command} convert -f #{file_format} -O #{required_format} #{@unpacking_dir}/#{@metadata.dc_identifier} #{output_dir}/#{new_file_name}")
       convert_cmd.run_command
       begin
         convert_cmd.error!

--- a/lib/itchy/image_transformer.rb
+++ b/lib/itchy/image_transformer.rb
@@ -46,7 +46,7 @@ module Itchy
           new_file_name = copy_same_format(unpacking_dir, metadata)
         else
           converter = Itchy::FormatConverter.new(unpacking_dir, metadata, vmcatcher_configuration)
-          new_file_name = converter.convert!(file_format, @options.required_format, @options.output_dir)
+          new_file_name = converter.convert!(file_format, @options.required_format, @options.output_dir, @options.qemu_img_binary)
         end
         remove_dir(unpacking_dir)
       rescue Itchy::Errors::FileInspectError, Itchy::Errors::FormatConversionError,

--- a/lib/itchy/image_transformer.rb
+++ b/lib/itchy/image_transformer.rb
@@ -64,7 +64,10 @@ module Itchy
     # @param unpacking_dir [String] name and path of the checked file
     # @return [String] image format
     def format(file)
-      image_format_tester = Mixlib::ShellOut.new("qemu-img info #{file}")
+
+      qemu_command = @options.qemu_img_binary || Itchy::BASIC_QEMU_COMMAND
+
+      image_format_tester = Mixlib::ShellOut.new("#{qemu_command} info #{file}")
       image_format_tester.run_command
       begin
         image_format_tester.error!

--- a/lib/itchy/image_transformer.rb
+++ b/lib/itchy/image_transformer.rb
@@ -202,7 +202,7 @@ module Itchy
     # @param vmcatcher_configuration [Itchy::VmcatcherConfiguration] current VMC configuration
     # @return [String] path to the newly created image directory
     def prepare_image_temp_dir(metadata, vmcatcher_configuration)
-      temp_dir = "#{vmcatcher_configuration.cache_dir_cache}/temp/#{metadata.dc_identifier}"
+      temp_dir = "#{@options.temp_image_dir}/#{metadata.dc_identifier}"
 
       begin
         ::FileUtils.mkdir_p temp_dir

--- a/lib/itchy/image_transformer.rb
+++ b/lib/itchy/image_transformer.rb
@@ -122,7 +122,7 @@ module Itchy
       dir = Dir.new directory
       counter = 0
       files = dir['*']
-      files each do |file|
+      files.each do |file|
         file_format = format("#{directory}/#{file}")
         if KNOWN_IMAGE_FORMATS.include? file_format
           counter += 1

--- a/lib/itchy/version.rb
+++ b/lib/itchy/version.rb
@@ -1,3 +1,3 @@
 module Itchy
-  VERSION = '0.2.6' unless defined?(::Itchy::VERSION)
+  VERSION = '0.2.7' unless defined?(::Itchy::VERSION)
 end

--- a/lib/itchy/version.rb
+++ b/lib/itchy/version.rb
@@ -1,3 +1,3 @@
 module Itchy
-  VERSION = '0.2.5' unless defined?(::Itchy::VERSION)
+  VERSION = '0.2.6' unless defined?(::Itchy::VERSION)
 end


### PR DESCRIPTION
This adds usage of qemu-img binary path from config, fixes some typos and also changes the appearance of method options in binary. Also the path for temporary directory, where processed images are stored is now taken from config and it's not hardlinked anymore.